### PR TITLE
Update `preprocess` dependency to current version so that nested cond…

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "./bin/preprocess",
   "dependencies": {
     "optimist": "*",
-    "preprocess": "^2.3.1"
+    "preprocess": "^3.1.0"
   },
   "bin": {
     "preprocess": "./bin/preprocess"


### PR DESCRIPTION
…itionals are properly supported.

I noticed that nested conditionals like:

```
// @if someCond
...
// @if anotherCond
...
// @endif
// @endif
```

...weren't being properly handled using the existing `preprocess` v2.3.1 dependency. Updating it to the newest version (v3.1.0) resolved the issue.

The [relevant commit message](https://github.com/jsoverson/preprocess/commit/a719edd10ea7fb5c5381dcf939f360f325ae8c18) for `preprocess` v3.0.0 notes that its changes are "mostly backward-compatible" -- not sure if there are any changes that could cause issues for existing `preprocess-cli` users? If so, perhaps this change should also include a bump to v0.2.0, just to be safe?
